### PR TITLE
Support for PHPTal parsing and MySQL storage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Grammatista Changelog
 =====================
 
+0.1.2 (October ?, 2012)
+------------------------
+
+ADD: Support for PHPTal (Hash)
+ADD: Support for MySQL storage (Hash)
+
 0.1.1 (February ?, 2009)
 ------------------------
 

--- a/examples/test1.php
+++ b/examples/test1.php
@@ -29,8 +29,14 @@ Grammatista::registerParser('agsmarty', array(
 		),
 	),
 ));
+Grammatista::registerParser('agphptal', array(
+	'class' => 'GrammatistaParserPcrePhptal',
+	'options' => array(
+		'pcre.transform' => array("' . dquote . '" => '"')
+	)
+));
 
-Grammatista::setStorage(new GrammatistaStoragePdo(array('pdo.dsn' => 'sqlite:' . dirname(__FILE__) . '/' . $_SERVER['REQUEST_TIME'] . '.sqlite')));
+Grammatista::setStorage(new GrammatistaStorageSQLite(array('pdo.dsn' => 'sqlite:' . dirname(__FILE__) . '/' . $_SERVER['REQUEST_TIME'] . '.sqlite')));
 
 $logger = new GrammatistaLoggerShell();
 Grammatista::registerEventResponder('grammatista.parser.parsed', array($logger, 'log'));

--- a/examples/test1/wow.tal
+++ b/examples/test1/wow.tal
@@ -1,0 +1,12 @@
+<div class="zomg">
+
+	<h1 tal:content="php:tm._('wow', 'tal.baz')" />
+	
+	<p>There is ${php:count(foo) . ' ' . tm.__('lol', 'lolz', 1, 'tal.baz')} in here</p>
+	
+	<!-- 
+		!!For serious?!!
+		<p tal:content="php:tm._('lol', 'tal.baz')" />
+	-->
+	
+</div>

--- a/lib/Grammatista.class.php
+++ b/lib/Grammatista.class.php
@@ -14,7 +14,7 @@
  */
 class Grammatista
 {
-	const VERSION_NUMBER = '0.1.1';
+	const VERSION_NUMBER = '0.1.2';
 	const VERSION_STATUS = 'dev';
 	
 	/**
@@ -29,6 +29,7 @@ class Grammatista
 		'GrammatistaParserDwoo'               => 'Grammatista/Parser/Dwoo.class.php',
 		'GrammatistaParserPcre'               => 'Grammatista/Parser/Pcre.class.php',
 		'GrammatistaParserPcreSmarty'         => 'Grammatista/Parser/Pcre/Smarty.class.php',
+		'GrammatistaParserPcrePhptal'         => 'Grammatista/Parser/Pcre/Phptal.class.php',
 		'GrammatistaParserPcreSmartySlv3'     => 'Grammatista/Parser/Pcre/Smarty/Slv3.class.php',
 		'GrammatistaParserPhp'                => 'Grammatista/Parser/Php.class.php',
 		'GrammatistaParserPhpAgavi'           => 'Grammatista/Parser/Php/Agavi.class.php',
@@ -39,6 +40,8 @@ class Grammatista
 		'GrammatistaScannerFilesystemRecursivedirectoryiterator' => 'Grammatista/Scanner/Filesystem/Recursivedirectoryiterator.class.php',
 		'GrammatistaStorage'                  => 'Grammatista/Storage.class.php',
 		'GrammatistaStoragePdo'               => 'Grammatista/Storage/Pdo.class.php',
+		'GrammatistaStorageSQLite'            => 'Grammatista/Storage/SQLite.class.php',
+		'GrammatistaStorageMySQL'             => 'Grammatista/Storage/MySQL.class.php',
 		'GrammatistaTranslatable'             => 'Grammatista/Translatable.class.php',
 		'GrammatistaTranslatablePdo'          => 'Grammatista/Translatable/Pdo.class.php',
 		'GrammatistaValueholder'              => 'Grammatista/Valueholder.class.php',

--- a/lib/Grammatista/Parser/Pcre.class.php
+++ b/lib/Grammatista/Parser/Pcre.class.php
@@ -110,8 +110,8 @@ abstract class GrammatistaParserPcre extends GrammatistaParser
 	
 	protected function transform($value)
 	{
-		if(isset($this->options['pcre.transform']) && is_array($this->options['pcre.transform'])) {
-			foreach($this->options['pcre.transform'] as $search => $replace)
+		if(isset($this->options['pcre.transform'])) {
+			foreach((array)$this->options['pcre.transform'] as $search => $replace)
 			{
 				$value = str_replace($search, $replace, $value);
 			}

--- a/lib/Grammatista/Parser/Pcre.class.php
+++ b/lib/Grammatista/Parser/Pcre.class.php
@@ -68,6 +68,8 @@ abstract class GrammatistaParserPcre extends GrammatistaParser
 						if(!$this->validate($key, $value)) {
 							$problem = true;
 							// var_dump('problem!');
+						} else {
+							$info[$key] = $this->transform($value);
 						}
 					}
 					
@@ -104,6 +106,18 @@ abstract class GrammatistaParserPcre extends GrammatistaParser
 	protected function findLine($content, $offset)
 	{
 		return preg_match_all('/$/m', substr($content, 0, $offset), $matches);
+	}
+	
+	protected function transform($value)
+	{
+		if(isset($this->options['pcre.transform']) && is_array($this->options['pcre.transform'])) {
+			foreach($this->options['pcre.transform'] as $search => $replace)
+			{
+				$value = str_replace($search, $replace, $value);
+			}
+		}
+		
+		return $value;
 	}
 	
 	abstract protected function validate($name, $value);

--- a/lib/Grammatista/Parser/Pcre/Phptal.class.php
+++ b/lib/Grammatista/Parser/Pcre/Phptal.class.php
@@ -1,0 +1,46 @@
+<?php
+
+class GrammatistaParserPcrePhptal extends GrammatistaParserPcre
+{
+	public function __construct(array $options = array())
+	{
+		parent::__construct($options);
+
+		if(!isset($this->options['pcre.comment_pattern'])) {
+			$this->options['pcre.comment_pattern'] = '/\<!--\s*%s\s*(?P<comment>[^(-->)]+?)\s*-->(?!.*?php:.*?tm\._)/s';
+		}
+
+		if(!isset($this->options['pcre.patterns'])) {
+			$this->options['pcre.patterns'] = array(
+				'/php:.*?tm\._\((["\'](?P<singular_message>.+?)["\'])([,\s]+["\'](?P<domain>.+?)["\'])/ms' => true,
+				'/php:.*?tm\.__\((["\'](?P<singular_message>.+?)["\'])([,\s]+["\'](?P<plural_message>.+?)["\'])([,\s]+.+?)([,\s]+["\'](?P<domain>.+?)["\'])/ms' => true,
+			);
+		}
+	}
+
+	public function handles(GrammatistaEntity $entity)
+	{
+		$retval = $entity->type == 'tal';
+
+		if($retval) {
+			Grammatista::dispatchEvent('grammatista.parser.handles', array('entity' => $entity));
+		}
+
+		return $retval;
+	}
+
+	protected function validate($name, $value)
+	{
+		switch($name) {
+			case 'singular_message':
+			case 'plural_message':
+				return preg_match('/[\{\}]/', $value) == 0;
+			case 'domain':
+				return preg_match('/\$/', $value) == 0;
+			case 'comment':
+				return true;
+		}
+	}
+}
+
+?>

--- a/lib/Grammatista/Storage/MySQL.class.php
+++ b/lib/Grammatista/Storage/MySQL.class.php
@@ -6,10 +6,6 @@ class GrammatistaStorageMySQL extends GrammatistaStoragePdo
 	{	
 		parent::__construct($options);
 
-		foreach((array)$this->options['pdo.init_queries'] as $query) {
-			$this->connection->query($query);
-		}		
-	
 		// TODO: make configurable
 		$this->connection->exec('
 			DROP TABLE IF EXISTS translatables;

--- a/lib/Grammatista/Storage/MySQL.class.php
+++ b/lib/Grammatista/Storage/MySQL.class.php
@@ -1,0 +1,42 @@
+<?php
+
+class GrammatistaStorageMySQL extends GrammatistaStoragePdo
+{
+	public function __construct(array $options = array())
+	{	
+		parent::__construct($options);
+
+		foreach((array)$this->options['pdo.init_queries'] as $query) {
+			$this->connection->query($query);
+		}		
+	
+		// TODO: make configurable
+		$this->connection->exec('
+			DROP TABLE IF EXISTS translatables;
+			CREATE TABLE translatables(
+				item_name TEXT,
+				line INTEGER,
+				domain TEXT,
+				singular_message TEXT,
+				plural_message TEXT,
+				comment TEXT,
+				parser_name TEXT
+			) COLLATE utf8_unicode_ci
+		');
+	
+		$this->connection->exec('
+			DROP TABLE IF EXISTS warnings;
+			CREATE TABLE warnings(
+				item_name TEXT,
+				line INTEGER,
+				domain TEXT,
+				singular_message TEXT,
+				plural_message TEXT,
+				comment TEXT,
+				parser_name TEXT
+			) COLLATE utf8_unicode_ci
+		');
+	}
+}
+
+?>

--- a/lib/Grammatista/Storage/Pdo.class.php
+++ b/lib/Grammatista/Storage/Pdo.class.php
@@ -26,6 +26,10 @@ abstract class GrammatistaStoragePdo extends GrammatistaStorage
 		foreach((array)$this->options['pdo.attributes'] as $attribute => $value) {
 			$this->connection->setAttribute($attribute, $value);
 		}
+		
+		foreach((array)$this->options['pdo.init_queries'] as $query) {
+			$this->connection->query($query);
+		}		
 	}	
 	
 	public function readTranslatables($unique = true, $order = 'domain')

--- a/lib/Grammatista/Storage/Pdo.class.php
+++ b/lib/Grammatista/Storage/Pdo.class.php
@@ -1,6 +1,6 @@
 <?php
 
-class GrammatistaStoragePdo extends GrammatistaStorage
+abstract class GrammatistaStoragePdo extends GrammatistaStorage
 {
 	protected $connection = null;
 	
@@ -14,47 +14,19 @@ class GrammatistaStoragePdo extends GrammatistaStorage
 		$this->options['pdo.init_queries'] = array();
 		$this->options['pdo.translatable_class_name'] = 'GrammatistaTranslatablePdo';
 		$this->options['pdo.translatable_class_ctorargs'] = array();
-		
+	
 		parent::__construct($options);
-		
+	
 		// TODO: checks <:
 		if(!isset($this->options['pdo.attributes'][PDO::ATTR_ERRMODE])) {
 			$this->options['pdo.attributes'][PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
 		}
-		
+	
 		$this->connection = new PDO($this->options['pdo.dsn'], $this->options['pdo.username'], $this->options['pdo.password'], $this->options['pdo.driver_options']);
 		foreach((array)$this->options['pdo.attributes'] as $attribute => $value) {
 			$this->connection->setAttribute($attribute, $value);
 		}
-		foreach((array)$this->options['pdo.init_queries'] as $query) {
-			$this->connection->executeQuery($query);
-		}
-		
-		// TODO: make configurable
-		$this->connection->exec('
-			CREATE TABLE translatables(
-				item_name TEXT,
-				line INTEGER,
-				domain TEXT,
-				singular_message TEXT,
-				plural_message TEXT,
-				comment TEXT,
-				parser_name TEXT
-			)
-		');
-		
-		$this->connection->exec('
-			CREATE TABLE warnings(
-				item_name TEXT,
-				line INTEGER,
-				domain TEXT,
-				singular_message TEXT,
-				plural_message TEXT,
-				comment TEXT,
-				parser_name TEXT
-			)
-		');
-	}
+	}	
 	
 	public function readTranslatables($unique = true, $order = 'domain')
 	{

--- a/lib/Grammatista/Storage/SQLite.class.php
+++ b/lib/Grammatista/Storage/SQLite.class.php
@@ -1,0 +1,40 @@
+<?php
+
+class GrammatistaStorageSQLite extends GrammatistaStoragePdo
+{
+	public function __construct(array $options = array())
+	{
+		parent::__construct($options);
+		
+		foreach((array)$this->options['pdo.init_queries'] as $query) {
+			$this->connection->executeQuery($query);
+		}
+		
+		// TODO: make configurable
+		$this->connection->exec('
+			CREATE TABLE translatables(
+				item_name TEXT,
+				line INTEGER,
+				domain TEXT,
+				singular_message TEXT,
+				plural_message TEXT,
+				comment TEXT,
+				parser_name TEXT
+			)
+		');
+		
+		$this->connection->exec('
+			CREATE TABLE warnings(
+				item_name TEXT,
+				line INTEGER,
+				domain TEXT,
+				singular_message TEXT,
+				plural_message TEXT,
+				comment TEXT,
+				parser_name TEXT
+			)
+		');
+	}
+}
+
+?>

--- a/lib/Grammatista/Storage/SQLite.class.php
+++ b/lib/Grammatista/Storage/SQLite.class.php
@@ -5,11 +5,7 @@ class GrammatistaStorageSQLite extends GrammatistaStoragePdo
 	public function __construct(array $options = array())
 	{
 		parent::__construct($options);
-		
-		foreach((array)$this->options['pdo.init_queries'] as $query) {
-			$this->connection->executeQuery($query);
-		}
-		
+
 		// TODO: make configurable
 		$this->connection->exec('
 			CREATE TABLE translatables(


### PR DESCRIPTION
GrammatistaStoragePdo is now abstract so existing scripts should switch to GrammatistaStorageSQLite.

PHPTal parsing requires post parse transformations for quote handling.
